### PR TITLE
fix boost installation

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -33,11 +33,8 @@ ENV NODE_PATH=/usr/local/lib/node_modules
 RUN npm install -g typescript@5.3.3 tsx@4.7.1
 
 # gcc 9
-RUN apt-get install -y build-essential && apt-get install -y g++ \
-    && curl -o /workspace/download/boost_1_84_0.tar.gz -SL https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz \
-    && tar -zxf /workspace/download/boost_1_84_0.tar.gz && rm /workspace/download/boost_1_84_0.tar.gz && cd boost_1_84_0 \
-    && ./bootstrap.sh --prefix=/usr/ && ./b2 && ./b2 install \
-    && cd .. && rm -r boost_1_84_0
+RUN apt-get install -y build-essential g++ libboost-all-dev
+
 RUN curl -o /workspace/download/openssl.tar.gz -SL https://www.openssl.org/source/old/3.0/openssl-3.0.11.tar.gz \
     && tar -zxf /workspace/download/openssl.tar.gz && cd openssl-3.0.11 && ./Configure && make && make install \
     && rm /workspace/download/openssl.tar.gz && cd .. && rm -r openssl-3.0.11

--- a/scripts/Dockerfile.base.us
+++ b/scripts/Dockerfile.base.us
@@ -29,11 +29,7 @@ ENV NODE_PATH=/usr/local/lib/node_modules
 RUN npm install -g typescript@5.3.3 tsx@4.7.1
 
 # gcc 9
-RUN apt-get install -y build-essential && apt-get install -y g++ \
-    && curl -o /workspace/download/boost_1_84_0.tar.gz -SL https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz \
-    && tar -zxf /workspace/download/boost_1_84_0.tar.gz && rm /workspace/download/boost_1_84_0.tar.gz && cd boost_1_84_0 \
-    && ./bootstrap.sh --prefix=/usr/ && ./b2 && ./b2 install \
-    && cd .. && rm -r boost_1_84_0
+RUN apt-get install -y build-essential g++ libboost-all-dev
 RUN curl -o /workspace/download/openssl.tar.gz -SL https://www.openssl.org/source/old/3.0/openssl-3.0.11.tar.gz \
     && tar -zxf /workspace/download/openssl.tar.gz && cd openssl-3.0.11 && ./Configure && make && make install \
     && rm /workspace/download/openssl.tar.gz && cd .. && rm -r openssl-3.0.11


### PR DESCRIPTION
Using apt install libboost-all-dev instead of download from url, because the url is not valid.