### PR TITLE
Fix: add ipython dependency for python env in requirements.txt

### DIFF
--- a/runtime/python/requirements.txt
+++ b/runtime/python/requirements.txt
@@ -100,3 +100,4 @@ jupyter==1.0.0
 jupyter_client==8.6.2
 seaborn==0.13.2
 tabulate==0.9.0
+ipython==8.18.1


### PR DESCRIPTION
Here is a description of the issue:

When attempting to follow the instructions in the `README` file of the main branch to run the `jupyter mode` demo, we encountered some problems. The specific code is as follows:

```python
from sandbox_fusion import run_code, RunCodeRequest, set_endpoint, run_jupyter, RunJupyterRequest

set_endpoint('http://localhost:8080')

# Using the default retry count (5 times)
res = run_code(RunCodeRequest(code='print(123)', language='python'))

print(res)

import json
import base64
import requests

cells = [
    '''
a = 123
# display stream
a
    ''',
    '''
# stdout & stderr stream
print(a)
import sys
sys.stderr.write(str(a))
    ''',
    '''
raise Exception("This exception doesn't interrupt cell execution")
    ''',
    '''
import matplotlib.pyplot as plt

plt.plot([1, 2, 3], [1, 2, 3])
    '''
]

response = requests.post('http://localhost:8080/run_jupyter', json={
    'cells': cells,
    'kernel': 'python3'
})

print(json.dumps(response.json(), indent=2))
```

However, when running the above code, the following error occurred:

```
kernel failed to start, trying a new one. error: 
IPython 8.31+ supports Python 3.11 and above, following SPEC0
IPython 8.19+ supports Python 3.10 and above, following SPEC0.
IPython 8.13+ supports Python 3.9 and above, following NEP 29.
IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
Python 3.3 and 3.4 were supported up to IPython 6.x.
Python 3.5 was supported with IPython 7.0 to 7.9.
Python 3.6 was supported with IPython up to 7.16.
Python 3.7 was still supported with the 7.x branch.

See IPython `README.rst` file for more information:

    https://github.com/ipython/ipython/blob/main/README.rst  
```

After investigation, we found that this error is likely due to the incompatibility between the installed `IPython` version and the used `Python` version in the current environment. According to the `README.rst` file of `IPython`, different versions of `IPython` have specific support ranges for `Python` versions. For example, `IPython 8.31+` supports `Python 3.11` and above, while our environment might be using a lower version of `Python`.

To resolve this issue, we tried the following methods:

1. **Check and upgrade the `Python` version**: Ensure that the `Python` version in the current environment meets the requirements of `IPython`. You can check the current `Python` version by running `python --version` or `python3 --version`. If the version is lower, you can use tools like `pyenv` to install and switch to a suitable `Python` version.

2. **Install or upgrade `IPython`**: Install or upgrade to the appropriate `IPython` version based on the current `Python` version. For example, if you are using `Python 3.10`, you can install `IPython 8.19+`. You can install or upgrade by running `pip install ipython==8.19` (adjust according to the specific version number).

3. **Check environment dependencies**: Ensure that all necessary dependencies, including `matplotlib`, are installed in the environment. You can install them by running `pip install -r requirements.txt` (assuming the `requirements.txt` file lists all the dependencies).

After the above attempts, we successfully resolved the issue of `jupyter mode` not running and were able to execute the demo code normally. The ipython==8.18.1 can solve the problem.

We solve the problem in our env by:
```
FROM volcengine/sandbox-fusion:server-20250609
RUN /root/miniconda3/envs/sandbox-runtime/bin/pip install ipython==8.18.1 --force-reinstall
docker build -t sandbox-fixed:20250609 -f Dockerfile.mysandbox .
docker run -it -p 8080:8080 sandbox-fixed:20250609
```

The problem can also be solve by: Add the ipython==8.18.1 into the requirements.txt file
After updating the requirement.txt, we build a new docker under the README instructions locally and the jupyter mode code can be executed successfully. 

This PR is to update the requirements.txt file to include the `ipython==8.18.1` dependency, ensuring that the `jupyter mode` demo can run successfully in the specified environment. New docker should be built and dispatched to Dockerhub after merging this branch
