### PR TITLE
fix: Only call disconnect when the database handler is available

### DIFF
--- a/sandbox/server/server.py
+++ b/sandbox/server/server.py
@@ -35,8 +35,10 @@ async def lifespan(app: FastAPI):
     datalake, sqlite = await get_databases()
     logger.info(f'database initialized')
     yield
-    await datalake.disconnect()
-    await sqlite.disconnect()
+    if datalake is not None:
+        await datalake.disconnect()
+    if sqlite is not None:
+        await sqlite.disconnect()
 
 
 app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
TO fix the following error:

```log
INFO:     Shutting down
INFO:     Waiting for application shutdown.
ERROR:    Traceback (most recent call last):
  File "/root/miniconda3/lib/python3.11/site-packages/starlette/routing.py", line 677, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/root/miniconda3/lib/python3.11/contextlib.py", line 211, in __aexit__
    await anext(self.gen)
  File "/root/sandbox/sandbox/server/server.py", line 38, in lifespan
    await datalake.disconnect()
          ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'disconnect'

ERROR:    Application shutdown failed. Exiting.
```