### PR TITLE
fix python version

### DIFF
--- a/runtime/python/install-python-runtime.sh
+++ b/runtime/python/install-python-runtime.sh
@@ -10,7 +10,7 @@ do
 done
 
 rm -f ~/.condarc
-conda create -n sandbox-runtime -y python=3.10
+conda create -n sandbox-runtime -y python=3.11
 
 source activate sandbox-runtime
 


### PR DESCRIPTION
meson-python: error: The package requires Python version >=3.11, running on 3.10.18