### PR TITLE
feat(pytest): support extra command-line arguments

### DIFF
--- a/runtime/python/requirements.txt
+++ b/runtime/python/requirements.txt
@@ -46,6 +46,7 @@ pyberny==0.6.3
 redis==5.0.1
 pika==1.3.2
 pytest==7.4.4
+pytest-json-report==1.5.0
 pymongo==4.6.1
 mongomock==4.1.2
 scikit-learn==1.4.0

--- a/sandbox/runners/major.py
+++ b/sandbox/runners/major.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -89,7 +90,8 @@ async def run_pytest(args: CodeRunArgs) -> CodeRunResult:
         with tempfile.NamedTemporaryFile(mode='w', dir=tmp_dir, suffix='.py', delete=False) as f:
             f.write(args.code)
 
-        return await run_commands(None, f'pytest {f.name}', tmp_dir, get_python_rt_env('sandbox-runtime'), args)
+        run_command = shlex.join(['pytest', f.name, *args.args])
+        return await run_commands(None, run_command, tmp_dir, get_python_rt_env('sandbox-runtime'), args)
 
 
 async def run_cpp(args: CodeRunArgs) -> CodeRunResult:

--- a/sandbox/runners/types.py
+++ b/sandbox/runners/types.py
@@ -40,6 +40,7 @@ class CodeRunArgs(BaseModel):
     memory_limit_MB: int = -1
     stdin: Optional[str] = None
     fetch_files: List[str] = []
+    args: List[str] = Field([], description='additional command-line arguments passed to pytest')
 
 
 class CodeRunResult(BaseModel):

--- a/sandbox/server/sandbox_api.py
+++ b/sandbox/server/sandbox_api.py
@@ -46,6 +46,7 @@ class RunCodeRequest(BaseModel):
     language: Language = Field(..., examples=['python'], description='the language or execution mode to run the code')
     files: Dict[str, Optional[str]] = Field({}, description='a dict from file path to base64 encoded file content')
     fetch_files: List[str] = Field([], description='a list of file paths to fetch after code execution')
+    args: List[str] = Field([], description='additional command-line arguments passed to pytest')
 
 
 class RunStatus(str, Enum):

--- a/sandbox/tests/runners/test_pytest.py
+++ b/sandbox/tests/runners/test_pytest.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import json
+import shlex
+
 from fastapi.testclient import TestClient
 
+from sandbox.runners.major import run_pytest
+from sandbox.runners.types import CodeRunArgs, CodeRunResult
+from sandbox.server import sandbox_api
 from sandbox.server.sandbox_api import RunCodeRequest, RunCodeResponse, RunStatus
 from sandbox.server.server import app
 
@@ -113,6 +120,56 @@ class Testword_count:
         assert "'this': 1\n'sentence': 1\n'has': 1\n'some': 1\n'punctuation': 1\n'like': 1\n'commas': 1\n'and': 1\n'periods': 1\n" not in captured.out
 '''
 
+selective_code = r'''
+def test_requested():
+    assert True
+
+
+def test_unselected_failure():
+    assert False
+'''
+
+
+def test_pytest_args_forwarded_to_runner(monkeypatch):
+    extra_args = ['-k', 'test_requested', '; touch /tmp/should-not-exist']
+    captured = {}
+
+    async def fake_runner(args):
+        captured['args'] = args.args
+        return CodeRunResult()
+
+    monkeypatch.setitem(sandbox_api.CODE_RUNNERS, 'pytest', fake_runner)
+    request = RunCodeRequest(language='pytest', code=selective_code, args=extra_args)
+    response = client.post('/run_code', json=request.model_dump())
+
+    assert response.status_code == 200
+    assert RunCodeResponse(**response.json()).status == RunStatus.Success
+    assert captured['args'] == extra_args
+
+
+async def test_pytest_args_are_shell_quoted(tmp_path, mocker):
+    extra_args = [
+        '--json-report-file=report with spaces.json',
+        '; touch /tmp/should-not-exist',
+        '$(touch /tmp/also-not)',
+    ]
+    captured = {}
+
+    async def fake_run_commands(compile_command, run_command, cwd, extra_env, args):
+        captured['command'] = run_command
+        return CodeRunResult()
+
+    mocker.patch('sandbox.runners.major.get_tmp_dir', return_value=str(tmp_path))
+    mocker.patch('sandbox.runners.major.get_python_rt_env', return_value={})
+    mocker.patch('sandbox.runners.major.run_commands', side_effect=fake_run_commands)
+
+    await run_pytest(CodeRunArgs(code='def test_ok(): pass', args=extra_args))
+
+    argv = shlex.split(captured['command'])
+    assert argv[0] == 'pytest'
+    assert argv[1].endswith('.py')
+    assert argv[2:] == extra_args
+
 
 def test_pytest_pass():
     request = RunCodeRequest(language='python', code=code, run_timeout=5)
@@ -141,3 +198,18 @@ def test_pytest_fail():
     assert response.status_code == 200
     result = RunCodeResponse(**response.json())
     assert result.status == RunStatus.Failed
+
+
+def test_pytest_args_generate_fetched_report():
+    request = RunCodeRequest(language='pytest',
+                             code=code,
+                             args=['--cov-branch', '--json-report', '--json-report-file=report.json'],
+                             fetch_files=['report.json'],
+                             run_timeout=10)
+    response = client.post('/run_code', json=request.model_dump())
+
+    assert response.status_code == 200
+    result = RunCodeResponse(**response.json())
+    assert result.status == RunStatus.Success
+    report = json.loads(base64.b64decode(result.files['report.json']))
+    assert report['summary']['passed'] == 2

--- a/scripts/client/src/sandbox_fusion/models.py
+++ b/scripts/client/src/sandbox_fusion/models.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Dict, Literal, Optional, List, Any, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+
 if TYPE_CHECKING:
     from pydantic.v1 import BaseModel, Field
 else:
@@ -46,6 +47,7 @@ class CodeRunArgs(BaseModel):
     run_timeout: float = 10
     stdin: Optional[str] = None
     fetch_files: List[str] = []
+    args: List[str] = []
 
 
 class CodeRunResult(BaseModel):
@@ -120,6 +122,7 @@ class RunCodeRequest(BaseModel):
     language: Language = Field(..., examples=['python'], description='the language or execution mode to run the code')
     files: Dict[str, Optional[str]] = Field({}, description='a dict from file path to base64 encoded file content')
     fetch_files: List[str] = Field([], description='a list of file paths to fetch after code execution')
+    args: List[str] = Field([], description='additional command-line arguments passed to pytest')
 
 
 class RunCodeResponse(BaseModel):


### PR DESCRIPTION
## Summary

- add an `args` field to the run-code API, internal runner model, and Python client
- pass pytest arguments with shell-safe quoting so each caller-provided token keeps its argv boundary
- install `pytest-json-report` in the Python runtime so the issue's JSON-report example works
- cover API propagation, shell metacharacter quoting, and fetching a generated JSON report

## Testing

- targeted API/runner tests: 2 passed
- reproduced the issue's pytest JSON-report command directly: 1 passed; generated report parsed successfully
- changed-file isort, YAPF, pycln, compileall, and `pip check`: passed
- full `make check` was not run locally because the sandbox test harness requires Linux `resource`, `/bin/bash`, and the prebuilt `sandbox-runtime` environment; the added end-to-end test exercises that environment in project CI

Fixes #78